### PR TITLE
Fix for logrotate_app.rb. Was broken when params[:enable] == false.

### DIFF
--- a/definitions/logrotate_app.rb
+++ b/definitions/logrotate_app.rb
@@ -43,7 +43,7 @@ define :logrotate_app, :enable => true, :frequency => "weekly", :template => "lo
   else
 
     execute "rm /etc/logrotate.d/#{params[:name]}" do
-      only_if FileTest.exists?("/etc/logrotate.d/#{params[:name]}")
+    only_if { FileTest.exists?("/etc/logrotate.d/#{params[:name]}") }
       command "rm /etc/logrotate.d/#{params[:name]}"
     end
 


### PR DESCRIPTION
only_if doesn't accept True. It wants a block, so this puts the FileTest in a block. 

Without this, logrotate_app failed  when params[:enable] was false, at least with Chef 10.12 and 10.16.6.
